### PR TITLE
Format the generated code

### DIFF
--- a/cli/bin/supadart.dart
+++ b/cli/bin/supadart.dart
@@ -90,11 +90,14 @@ void main(List<String> arguments) async {
     }
 
     String outputPath = results['output'] ?? 'lib/models/';
-    codeOutput.forEach((className, classCode) {
+    codeOutput.forEach((className, classCode) async {
       // Create if not exists
       File file = File('$outputPath$className.dart');
       file.createSync(recursive: true);
       file.writeAsStringSync(classCode.toString());
+
+      // Format the generated code
+      await formatCode(file.path);
 
       print("*** Generated $outputPath$className.dart ***");
     });
@@ -110,6 +113,9 @@ void main(List<String> arguments) async {
     File file = File(outputPath);
     file.createSync(recursive: true);
     file.writeAsStringSync(codeOutput);
+
+    // Format the generated code
+    await formatCode(file.path);
 
     print("*** Classes generated successfully ***");
     print("*** Output: $outputPath ***");
@@ -127,4 +133,17 @@ Future<dynamic> fetchGeneratedClasses(
       return null;
     }
   });
+}
+
+Future<void> formatCode(String path) async {
+  try {
+    ProcessResult result = await Process.run('dart', ['format', path]);
+    if (result.exitCode != 0) {
+      print('Failed to format code: ${result.stderr}');
+    } else {
+      print('*** Formatted $path ***');
+    }
+  } catch (e) {
+    print('Failed to format code: $e');
+  }
 }


### PR DESCRIPTION
To facilitate code change review after each generation, this feature has been added to format the generated code after files are written. 

To minimize the CLI package size, we currently rely on the Dart SDK on the client device, but this may lead to some instability from the shell execution environment.

Alternatively, we could import pub packages similar to `dart_style` into CLI application.