### PR TITLE
fectching Swagger should try without apikey

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.5.1
+
+- initiate 2nd Swagger Request without the apikey if the first request fails
+
 ## 1.5.0
 
 - Support for enum types

--- a/cli/bin/supadart.dart
+++ b/cli/bin/supadart.dart
@@ -5,7 +5,7 @@ import 'package:yaml/yaml.dart';
 import 'package:supadart/generator/generator.dart';
 import 'package:supadart/generator/swagger.dart';
 
-const String version = 'v1.5.0';
+const String version = 'v1.5.1';
 const String red = '\x1B[31m'; // Red text
 const String green = '\x1B[32m'; // Green text
 const String blue = '\x1B[34m'; // Blue text

--- a/cli/lib/generator/swagger.dart
+++ b/cli/lib/generator/swagger.dart
@@ -6,13 +6,23 @@ import 'package:http/http.dart' as http;
 Future<DatabaseSwagger?> fetchDatabaseSwagger(
     String url, String anonKey) async {
   final response = await http.get(Uri.parse('$url/rest/v1/?apikey=$anonKey'));
+  String responseBody = "";
   if (response.statusCode == 200) {
     return DatabaseSwagger.fromJson(jsonDecode(response.body));
   } else {
     print("Error Fetching Supabase Swagger");
-    print(response.body);
-    return null;
+    responseBody = response.body;
   }
+
+  print("Trying without the api key...");
+  final response2 = await http.get(Uri.parse('$url/rest/v1/'));
+  if (response2.statusCode == 200) {
+    print("Fetched Supabase Swagger!");
+    return DatabaseSwagger.fromJson(jsonDecode(response.body));
+  }
+
+  print(responseBody);
+  return null;
 }
 
 class DatabaseSwagger {

--- a/cli/pubspec.yaml
+++ b/cli/pubspec.yaml
@@ -1,6 +1,6 @@
 name: supadart
 description: Generate Dart classes from your Supabase schema.
-version: 1.5.0
+version: 1.5.1
 
 repository: https://github.com/mmvergara/supadart
 homepage: https://github.com/mmvergara/supadart

--- a/web/lib/generator/swagger.dart
+++ b/web/lib/generator/swagger.dart
@@ -6,13 +6,23 @@ import 'package:http/http.dart' as http;
 Future<DatabaseSwagger?> fetchDatabaseSwagger(
     String url, String anonKey) async {
   final response = await http.get(Uri.parse('$url/rest/v1/?apikey=$anonKey'));
+  String responseBody = "";
   if (response.statusCode == 200) {
     return DatabaseSwagger.fromJson(jsonDecode(response.body));
   } else {
     print("Error Fetching Supabase Swagger");
-    print(response.body);
-    return null;
+    responseBody = response.body;
   }
+
+  print("Trying without the api key...");
+  final response2 = await http.get(Uri.parse('$url/rest/v1/'));
+  if (response2.statusCode == 200) {
+    print("Fetched Supabase Swagger!");
+    return DatabaseSwagger.fromJson(jsonDecode(response.body));
+  }
+
+  print(responseBody);
+  return null;
 }
 
 class DatabaseSwagger {


### PR DESCRIPTION
In this issue, it is found that when using cli for local development ( where the port is 54321 )
the apikey is not needed to fetch the swagger json

https://github.com/mmvergara/supadart/issues/54

this update will initiate a second request without the apikey if the first one (one with the apikey as queryparams) fails.