### PR TITLE
feat: add storage client extension generator

### DIFF
--- a/cli/bin/supadart.dart
+++ b/cli/bin/supadart.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 import 'package:args/args.dart';
 import 'package:supadart/config_init.dart';
 import 'package:supadart/generators/index.dart';
+import 'package:supadart/generators/storage/fetch_storage.dart';
 import 'package:supadart/generators/utils/fetch_swagger.dart';
 import 'package:yaml/yaml.dart';
 
@@ -128,10 +129,18 @@ Future<void> generateModels(Map<String, dynamic> options) async {
     exit(1);
   }
 
+  final storageList =
+      await fetchStorageList(options['url'], options['anonKey']);
+  if (storageList == null) {
+    print('Failed to fetch storage');
+    exit(1);
+  }
+
   print('Generating models...');
   final stopwatch = Stopwatch()..start();
   final files = supadartRun(
     databaseSwagger,
+    storageList,
     options['isDart'],
     options['isSeparated'],
     options['mappings'],

--- a/cli/lib/generators/index.dart
+++ b/cli/lib/generators/index.dart
@@ -1,4 +1,5 @@
 import 'package:yaml/yaml.dart';
+import 'storage/storage.dart';
 import 'swagger/swagger.dart';
 import 'standalone/exports.dart';
 import 'standalone/enums.dart';
@@ -10,6 +11,7 @@ import 'class/class.dart';
 
 List<GeneratedFile> supadartRun(
   DatabaseSwagger swagger,
+  Storage storageList,
   bool isDart,
   bool isSeparated,
   YamlMap? mappings,
@@ -18,6 +20,7 @@ List<GeneratedFile> supadartRun(
   final dartClasses = generateDartClasses(swagger, mappings, exclude);
 
   final clientExtension = generateClientExtension(swagger);
+  final storageClientExtension = generateStorageClientExtension(storageList);
   final modelExports = generateExports(swagger, mappings);
   final enums = generateEnums(swagger);
 
@@ -43,6 +46,7 @@ List<GeneratedFile> supadartRun(
 
   final supadartGenerator = SupadartGenerator(
     clientExtension: clientExtension,
+    storageClientExtension: storageClientExtension,
     dartClasses: dartClasses,
     modelExports: modelExports,
     enums: enums,
@@ -69,6 +73,7 @@ class GeneratedFile {
 
 class SupadartGenerator {
   final String clientExtension;
+  final String storageClientExtension;
   final List<DartClass> dartClasses;
   final String modelExports;
   final String enums;
@@ -85,6 +90,7 @@ class SupadartGenerator {
 
   SupadartGenerator({
     required this.clientExtension,
+    required this.storageClientExtension,
     required this.dartClasses,
     required this.modelExports,
     required this.enums,
@@ -164,6 +170,9 @@ import 'supadart_header.dart';
       "\n",
       "// Supabase Client Extension",
       clientExtension,
+      "\n",
+      "// Supabase Storage Client Extension",
+      storageClientExtension,
       "\n",
       "// Enums",
       enums,

--- a/cli/lib/generators/standalone/client_extension.dart
+++ b/cli/lib/generators/standalone/client_extension.dart
@@ -1,3 +1,4 @@
+import '../storage/storage.dart';
 import '../swagger/swagger.dart';
 
 String generateClientExtension(DatabaseSwagger swagger) {
@@ -5,6 +6,17 @@ String generateClientExtension(DatabaseSwagger swagger) {
   swagger.definitions.forEach((tableName, _) {
     code.write(
         "SupabaseQueryBuilder get ${tableName.toLowerCase()} => from('$tableName');\n");
+  });
+  code.write('}\n');
+  return code.toString();
+}
+
+String generateStorageClientExtension(Storage storageList) {
+  final code = StringBuffer(
+      'extension SupadartStorageClient on SupabaseStorageClient {\n');
+  storageList.buckets.forEach((bucket) {
+    code.write(
+        "StorageFileApi get ${bucket.name} => from('${bucket.name}');\n");
   });
   code.write('}\n');
   return code.toString();

--- a/cli/lib/generators/storage/fetch_storage.dart
+++ b/cli/lib/generators/storage/fetch_storage.dart
@@ -1,0 +1,60 @@
+import 'dart:convert';
+import 'dart:io';
+import 'package:http/http.dart' as http;
+import 'storage.dart';
+
+Future<Storage?> fetchStorageList(String url, String anonKey) async {
+  if (!url.startsWith("http://") && !url.startsWith("https://")) {
+    url = "https://$url"; // Default to HTTPS if no scheme is provided
+  }
+  try {
+    // First attempt with API key
+    final response = await _secureRequest('$url/storage/v1/bucket/', anonKey);
+    if (response.statusCode == 200) {
+      return Storage.fromJson(jsonDecode(response.body));
+    }
+    print(
+        "Failed to fetch Supabase storage information. Status code: ${response.statusCode}");
+    print("Response body: ${response.body}");
+  } catch (e) {
+    print("Error fetching Supabase storage information: $e");
+  }
+  return null;
+}
+
+Future<http.Response> _secureRequest(String url, String anonKey,
+    {bool allowHttpFallback = true}) async {
+  var headers = {'Authorization': 'Bearer $anonKey'};
+
+  try {
+    return await http.get(
+      Uri.parse(url),
+      headers: headers,
+    );
+  } on HandshakeException catch (e) {
+    print("HandshakeException occurred: $e");
+    print("Attempting with a custom HTTP client...");
+
+    final httpClient = HttpClient()
+      ..badCertificateCallback =
+          ((X509Certificate cert, String host, int port) => true);
+
+    final uri = Uri.parse(url);
+    final request = await httpClient.getUrl(uri);
+    final response = await request.close();
+
+    return http.Response(
+      await response.transform(utf8.decoder).join(),
+      response.statusCode,
+    );
+  } on SocketException catch (e) {
+    print("SocketException occurred: $e");
+    if (url.startsWith("https://") && allowHttpFallback) {
+      print("Attempting to fallback to HTTP...");
+      return await _secureRequest(
+          url.replaceFirst("https://", "http://"), anonKey,
+          allowHttpFallback: false);
+    }
+    rethrow;
+  }
+}

--- a/cli/lib/generators/storage/storage.dart
+++ b/cli/lib/generators/storage/storage.dart
@@ -1,0 +1,13 @@
+import 'package:supabase/supabase.dart';
+
+class Storage {
+  final List<Bucket> buckets;
+
+  Storage(this.buckets);
+
+  factory Storage.fromJson(List<dynamic> json) {
+    return Storage(
+      json.map((bucket) => Bucket.fromJson(bucket)).toList(),
+    );
+  }
+}

--- a/cli/test/storage_test.dart
+++ b/cli/test/storage_test.dart
@@ -1,0 +1,24 @@
+import 'package:dotenv/dotenv.dart';
+import 'package:supadart/generators/storage/fetch_storage.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('Fetch Supabase storage information', () async {
+    var env = DotEnv(includePlatformEnvironment: true)..load();
+    String? url = env['SUPABASE_URL'];
+    String? anonKey = env['SUPABASE_ANON_KEY'];
+
+    if (url == null || anonKey == null) {
+      print('Please provide SUPABASE_URL and SUPABASE_ANON_KEY in .env file');
+      return;
+    }
+
+    final storageJson = await fetchStorageList(url, anonKey);
+    if (storageJson == null) {
+      print("Failed to fetch storage list");
+      return;
+    } else {
+      expect(storageJson, isNotNull);
+    }
+  });
+}

--- a/cli/test/supadart_test.dart
+++ b/cli/test/supadart_test.dart
@@ -1,6 +1,7 @@
 import 'package:dotenv/dotenv.dart';
 import 'package:supabase/supabase.dart';
 import 'package:supadart/generators/index.dart';
+import 'package:supadart/generators/storage/fetch_storage.dart';
 import 'package:supadart/generators/utils/fetch_swagger.dart';
 import '../bin/supadart.dart';
 import 'boolean_bit_types.dart';
@@ -29,8 +30,15 @@ void main() async {
     return;
   }
 
+  final storageList = await fetchStorageList(url, anonKey);
+  if (storageList == null) {
+    print("Failed to fetch storage list");
+    return;
+  }
+
   // Test config, isDart: true, isSeperated:false, mappings:null
-  final files = supadartRun(databaseSwagger, true, false, null, []);
+  final files =
+      supadartRun(databaseSwagger, storageList, true, false, null, []);
   await generateAndFormatFiles(files, './test/models/');
   print("\nGenerated Fresh Models from DB");
 


### PR DESCRIPTION
We could get bucket list from `{SUPABASE_URL}/storage/v1/bucket`, like this:

``` json
[
    {
        "id": "avatars",
        "name": "avatars",
        "owner": "",
        "public": false,
        "file_size_limit": null,
        "allowed_mime_types": null,
        "created_at": "2024-09-23T00:51:09.228Z",
        "updated_at": "2024-09-23T00:51:09.228Z"
    },
    {
        "id": "covers",
        "name": "covers",
        "owner": "",
        "public": false,
        "file_size_limit": null,
        "allowed_mime_types": null,
        "created_at": "2024-09-21T15:06:45.988Z",
        "updated_at": "2024-09-21T15:06:45.988Z"
    }
]
```

This branch will generate storage client code additional according to the json, like this:

``` Dart
// Supabase Storage Client Extension
extension SupadartStorageClient on SupabaseStorageClient {
  StorageFileApi get avatars => from('avatars');
  StorageFileApi get covers => from('covers');
}
```
